### PR TITLE
Add CI/CD plan document

### DIFF
--- a/docs/ci-plan.md
+++ b/docs/ci-plan.md
@@ -1,0 +1,57 @@
+# CI/CD Plan
+
+This document outlines the proposed CI/CD pipeline using GitHub Actions.
+
+## Continuous Integration
+
+### Triggers
+- Pull requests and pushes to `main` or feature branches.
+
+### Steps
+1. **Checkout** the repository using `actions/checkout`.
+2. **Set up dependencies** (e.g., install Python or Node versions).
+3. **Install project dependencies** (e.g., `pip install -r requirements.txt` or `npm ci`).
+4. **Run linters** to enforce code style (e.g., `flake8`, `eslint`).
+5. **Execute tests** with coverage (e.g., `pytest --cov` or `npm test`).
+6. **Upload test artifacts** or coverage reports if required.
+
+## Continuous Deployment / Release
+
+### Triggers
+- Tagged commits matching `v*` or manual workflow dispatch.
+
+### Steps
+1. **Checkout** the code.
+2. **Set up environment** identical to CI.
+3. **Build artifacts** (e.g., Python wheels, Docker images).
+4. **Publish** artifacts to package registries or container registries.
+5. **Create GitHub Release** with changelog and uploaded artifacts.
+
+## Linting
+- Run as part of CI using `pre-commit`, `flake8`, or other relevant tools.
+- Fail the workflow if linting issues are found.
+
+## Testing
+- Tests should run in a clean environment and report coverage.
+- Consider parallelizing tests to speed up execution.
+
+## Example Workflow Skeleton
+```yaml
+name: CI
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - run: pip install -r requirements.txt
+      - run: flake8 .
+      - run: pytest --cov
+```


### PR DESCRIPTION
## Summary
- add `docs/ci-plan.md` describing the recommended GitHub Actions workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f8f51040c83268885e411f8c647ae