### PR TITLE
Add text processor script with docs and test

### DIFF
--- a/docs/repo-summary.md
+++ b/docs/repo-summary.md
@@ -1,0 +1,3 @@
+# Repository Summary
+
+LiOr is a minimal open-source project that primarily consists of documentation on advertising analysis, marketing methods, profit strategies, and development framework research. The README provides brief setup instructions for a Node.js environment, while the `src` and `tests` directories contain placeholder folders for future code. This repository serves as a starting point for experimentation and can be extended with new features or scripts.

--- a/docs/script-instructions.md
+++ b/docs/script-instructions.md
@@ -1,0 +1,21 @@
+# Using process_text.py
+
+The `process_text.py` script reads text, removes punctuation, converts it to lowercase, and prints the words in reverse order.
+
+## Running the script
+
+Run it with Python by providing a text file path or piping text into it:
+
+```bash
+# With a file
+python src/process_text.py path/to/file.txt
+
+# With piped input
+echo "Hello, World!" | python src/process_text.py
+```
+
+The second command outputs:
+
+```
+world hello
+```

--- a/src/process_text.py
+++ b/src/process_text.py
@@ -1,0 +1,16 @@
+import sys
+import string
+
+def process_text(text: str) -> str:
+    translator = str.maketrans('', '', string.punctuation)
+    cleaned = text.translate(translator).lower()
+    words = cleaned.split()
+    return ' '.join(reversed(words))
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        with open(sys.argv[1], "r", encoding="utf-8") as f:
+            data = f.read()
+    else:
+        data = sys.stdin.read()
+    print(process_text(data))

--- a/tests/test_process_text.py
+++ b/tests/test_process_text.py
@@ -1,0 +1,9 @@
+import unittest
+from src.process_text import process_text
+
+class ProcessTextTests(unittest.TestCase):
+    def test_reverse_words(self):
+        self.assertEqual(process_text("Hello, World!"), "world hello")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a repository summary doc
- create `process_text.py` for simple text processing
- document how to run the new script
- add a unit test for the script

## Testing
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_687f92639f288326836abde917736242